### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "orionx-sdk",
   "version": "1.3.10",
   "description": "Help developers with Orionx integrations",
-  "main": "build/index.js",
+  "main": "src/index.js",
   "scripts": {
     "dev": "watch 'npm run build' src",
     "build": "babel  src -d build",


### PR DESCRIPTION
allows use of the git branch via a package requirement. At the moment there is no release with the cancel order change that was just merged.
this allows a dev to spec.
 "orionx-sdk": "https://github.com/orionx-dev/orionx-sdk-js.git", 

in their package.json and use the latest master branch, as a work around till newer releases are rerolled.